### PR TITLE
Fix file extension typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ npm install rehype-retext
 
 ## Usage
 
-Say `example.md` looks as follows:
+Say `example.html` looks as follows:
 
 ```html
 <!doctype html>


### PR DESCRIPTION
Example file was misnamed `example.md` instead of `example.html`.